### PR TITLE
Using a name_prefix instead of name for template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@
 resource "google_compute_instance_template" "default" {
   count   = "${var.module_enabled ? 1 : 0}"
   project = "${var.project}"
-  name    = "${random_id.rand.dec}"
+  name_prefix = "${random_id.rand.dec}"
 
   machine_type = "${var.machine_type}"
 


### PR DESCRIPTION
## Problem:

When modifying anything in the instance template, for example, the machine type, it is unable to make this modification in terraform because of a duplicate named resource.  Using the lifecycle rule "create before destroy" is necessary, but because of this, there can not be two similarly named templates.  For example, when changing the machine type of a template you get...

`* google_compute_instance_template.default: Error creating instance template: googleapi: Error 409: The resource 'projects/projectname/global/instanceTemplates/default-7850850885292525658' already exists`

## Solution:

There is a terraform feature called "name_prefix" instead of "name" in most resources which helps fix this use-case.  This merge implements it for the google_compute_instance_template

## Notes:

Keep in mind, anyone that is using this template hopefully they have version locked (as is best practice for modules) the previous version, because if they did not they will suddenly have a changed name and re-creating of the template the next time they `terraform init` which might cause unexpected downtime.  I think it's something worth noting in the release notes, and to consider modifying your Usage Example to include version pinning (which it does not currently)