### PR TITLE
DEVOPS-114: Upgrade terraform & add update_strategy for regional instance groups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -87,6 +87,13 @@ resource "google_compute_instance_group_manager" "default" {
     health_check      = "${var.http_health_check ? element(concat(google_compute_health_check.mig-health-check.*.self_link, list("")), 0) : ""}"
     initial_delay_sec = "${var.hc_initial_delay}"
   }
+  rolling_update_policy {
+    type = "PROACTIVE"
+    minimal_action = "REPLACE"
+    max_surge_percent = 20
+    max_unavailable_fixed = 2
+    min_ready_sec = 50
+  }
 
   provisioner "local-exec" {
     when    = "destroy"

--- a/main.tf
+++ b/main.tf
@@ -162,6 +162,14 @@ resource "google_compute_region_instance_group_manager" "default" {
     command     = "${var.local_cmd_create}"
     interpreter = ["sh", "-c"]
   }
+  update_strategy         = "ROLLING_UPDATE"
+  wait_for_instances      = true
+  rolling_update_policy {
+    type                  = "PROACTIVE"
+    minimal_action        = "REPLACE"
+    max_surge_fixed       = "${var.autoscaling ? var.min_replicas : var.size}"
+    max_unavailable_fixed = 0
+  }
 }
 
 resource "google_compute_region_autoscaler" "default" {

--- a/override.tf
+++ b/override.tf
@@ -1,0 +1,3 @@
+resource "google_compute_instance_template" "default" {
+  tags = ["${var.target_tags}"] 
+}

--- a/variables.tf
+++ b/variables.tf
@@ -96,8 +96,8 @@ variable compute_image {
 }
 
 variable update_strategy {
-  description = "The strategy to apply when the instance template changes."
-  default = "RESTART"
+  description = "The strategy to apply when the instance template changes. See https://www.terraform.io/docs/providers/google/r/compute_instance_group_manager.html#update_strategy"
+  default = "ROLLING_UPDATE"
 }
 
 variable service_port {


### PR DESCRIPTION
nat bit is here, the rest are in https://github.com/ImpactInc/fq_configuration_management/pull/120

This PR is dependent on 120 being merged first since the Google provider is being upgraded from 1.8.0 -> 1.12.0 to get update_strategy support for regional instance group