### PR TITLE
Zonal enabled + module disabled throws error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -241,7 +241,7 @@ resource "google_compute_firewall" "mig-health-check" {
 
 data "google_compute_instance_group" "zonal" {
   count   = "${var.zonal ? 1 : 0}"
-  name    = "${google_compute_instance_group_manager.default.name}"
+  name    = "${element(concat(google_compute_instance_group_manager.default.*.name, list("unused")), 0)}"
   zone    = "${var.zone}"
   project = "${var.project}"
 }


### PR DESCRIPTION
# Problem
With zonal enabled and this module disabled, it would throw the following error...

```
* module.nat-zone-3.module.nat-gateway.data.google_compute_instance_group.zonal: Resource 'google_compute_instance_group_manager.default' not found for variable 'google_compute_instance_group_manager.default.name'
```

# Fix
The problem is an inherent problem lower level in Terraform, not "fully" respecting the count on a data resource to not try to resolve all dependencies inside an unused (count = 0) data stanza.  This is a well known problem, and the workaround is to have a cascading value to fall back onto, hence the concat+element trick.