### PR TITLE
Import of examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+**/terraform.tfstate*
+**/.terraform*
+**/backend.tf
+**/terraform.tfvars
+**/values-*.yaml

--- a/examples/autoscaling/README.md
+++ b/examples/autoscaling/README.md
@@ -1,0 +1,57 @@
+# Managed instance group autoscaling example
+
+This example creates a managed instance group with autoscaling enabled.
+
+## Set up the environment
+
+Configure your environment to use your default Google Cloud credentials:
+
+```bash
+gcloud auth application-default login
+export GOOGLE_PROJECT=$(gcloud config get-value project)
+```
+
+## Run Terraform
+
+Initialize and run Terraform to deploy the example:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+Open URL of load balancer in browser after the load balancer is ready:
+
+```bash
+EXTERNAL_IP=$(terraform output -module gce-lb-fr external_ip)
+(until curl -sf -o /dev/null http://${EXTERNAL_IP}; do echo "Waiting for Load Balancer... "; sleep 5 ; done) && open http://${EXTERNAL_IP}
+```
+
+## Testing autoscaling
+
+### CPU utilization test
+
+The CPU autoscaler tries to balance the load across the managed instance group by adding capacity so that the average load is at or below the target utilization. For details, see the [docs on CPU based autoscaling](https://cloud.google.com/compute/docs/autoscaler/scaling-cpu-load-balancing). 
+
+Run the [`lookbusy`](https://github.com/beloglazov/cpu-load-generator.git) command for 2 minutes on one of the instances to trigger CPU based autoscaling:
+
+```bash
+gcloud compute ssh $(terraform output instance) -- lookbusy -c 50
+```
+
+Open the [Cloud Console](https://console.cloud.google.com/compute/instanceGroups/details/us-central1/autoscale-cluster) to seee that 4 more instances were added to the group in response to the increased CPU.
+
+Press CTRL-C to stop the lookbusy command. After a few minutes, the managed instance group should scale back down.
+
+### Metric test
+
+### Load balancing utilization test
+
+## Cleanup
+
+Remove all resources created by terraform:
+
+```bash
+terraform destroy
+```

--- a/examples/autoscaling/gceme.sh.tpl
+++ b/examples/autoscaling/gceme.sh.tpl
@@ -1,0 +1,116 @@
+#!/bin/bash -xe
+
+apt-get update
+apt-get install -y apache2 php5
+
+# install lookbusy script to test autoscaling
+apt-get install -y build-essential git
+cd /tmp
+git clone https://github.com/beloglazov/cpu-load-generator.git
+./cpu-load-generator/install-lookbusy.sh
+cd -
+
+cat > /var/www/html/index.php <<'EOF'
+<?php
+function metadata_value($value) {
+    $opts = [
+        "http" => [
+            "method" => "GET",
+            "header" => "Metadata-Flavor: Google"
+        ]
+    ];
+    $context = stream_context_create($opts);
+    $content = file_get_contents("http://metadata/computeMetadata/v1/$value", false, $context);
+    return $content;
+}
+?>
+
+<!doctype html>
+<html>
+<head>
+<!-- Compiled and minified CSS -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.0/css/materialize.min.css">
+
+<!-- Compiled and minified JavaScript -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.0/js/materialize.min.js"></script>
+<title>Frontend Web Server</title>
+</head>
+<body>
+<div class="container">
+<div class="row">
+<div class="col s2">&nbsp;</div>
+<div class="col s8">
+
+
+<div class="card blue">
+<div class="card-content white-text">
+<div class="card-title">Backend that serviced this request</div>
+</div>
+<div class="card-content white">
+<table class="bordered">
+  <tbody>
+	<tr>
+	  <td>Name</td>
+	  <td><?php printf(metadata_value("instance/name")) ?></td>
+	</tr>
+	<tr>
+	  <td>ID</td>
+	  <td><?php printf(metadata_value("instance/id")) ?></td>
+	</tr>
+	<tr>
+	  <td>Hostname</td>
+	  <td><?php printf(metadata_value("instance/hostname")) ?></td>
+	</tr>
+	<tr>
+	  <td>Zone</td>
+	  <td><?php printf(metadata_value("instance/zone")) ?></td>
+	</tr>
+    <tr>
+	  <td>Machine Type</td>
+	  <td><?php printf(metadata_value("instance/machine-type")) ?></td>
+	</tr>
+	<tr>
+	  <td>Project</td>
+	  <td><?php printf(metadata_value("project/project-id")) ?></td>
+	</tr>
+	<tr>
+	  <td>Internal IP</td>
+	  <td><?php printf(metadata_value("instance/network-interfaces/0/ip")) ?></td>
+	</tr>
+	<tr>
+	  <td>External IP</td>
+	  <td><?php printf(metadata_value("instance/network-interfaces/0/access-configs/0/external-ip")) ?></td>
+	</tr>
+  </tbody>
+</table>
+</div>
+</div>
+
+<div class="card blue">
+<div class="card-content white-text">
+<div class="card-title">Proxy that handled this request</div>
+</div>
+<div class="card-content white">
+<table class="bordered">
+  <tbody>
+	<tr>
+	  <td>Address</td>
+	  <td><?php printf($_SERVER["HTTP_HOST"]); ?></td>
+	</tr>
+  </tbody>
+</table>
+</div>
+
+</div>
+</div>
+<div class="col s2">&nbsp;</div>
+</div>
+</div>
+</html>
+EOF
+sudo mv /var/www/html/index.html /var/www/html/index.html.old
+
+[[ -n "${PROXY_PATH}" ]] && mkdir -p /var/www/html/${PROXY_PATH} && cp /var/www/html/index.php /var/www/html/${PROXY_PATH}/index.php
+
+systemctl enable apache2
+systemctl restart apache2

--- a/examples/autoscaling/main.tf
+++ b/examples/autoscaling/main.tf
@@ -1,0 +1,83 @@
+variable "region" {
+  default = "us-central1"
+}
+
+provider "google" {
+  region = "${var.region}"
+}
+
+variable "network_name" {
+  default = "mig-autoscale-example"
+}
+
+resource "google_compute_network" "default" {
+  name                    = "${var.network_name}"
+  auto_create_subnetworks = "false"
+}
+
+resource "google_compute_subnetwork" "default" {
+  name                     = "${var.network_name}"
+  ip_cidr_range            = "10.127.0.0/20"
+  network                  = "${google_compute_network.default.self_link}"
+  region                   = "${var.region}"
+  private_ip_google_access = true
+}
+
+data "template_file" "startup-script" {
+  template = "${file("${format("%s/gceme.sh.tpl", path.module)}")}"
+
+  vars {
+    PROXY_PATH = ""
+  }
+}
+
+module "mig1" {
+  source             = "../../"
+  region             = "${var.region}"
+  zonal              = false
+  name               = "${var.network_name}"
+  wait_for_instances = true
+  autoscaling        = true
+
+  autoscaling_cpu = [{
+    target = 0.8
+  }]
+
+  size              = 1
+  min_replicas      = 1
+  max_replicas      = 5
+  cooldown_period   = 120
+  target_tags       = ["${var.network_name}"]
+  service_port      = 80
+  service_port_name = "http"
+  startup_script    = "${data.template_file.startup-script.rendered}"
+  target_pools      = ["${module.gce-lb-fr.target_pool}"]
+  network           = "${google_compute_subnetwork.default.name}"
+  subnetwork        = "${google_compute_subnetwork.default.name}"
+}
+
+module "gce-lb-fr" {
+  source       = "GoogleCloudPlatform/lb/google"
+  version      = "1.0.2"
+  region       = "${var.region}"
+  name         = "${var.network_name}-lb"
+  service_port = "${module.mig1.service_port}"
+  target_tags  = ["${module.mig1.target_tags}"]
+  network      = "${google_compute_subnetwork.default.name}"
+}
+
+// null resource used to create dependency with the instance group data source to trigger a refresh.
+resource "null_resource" "template" {
+  triggers {
+    instance_template = "${element(module.mig1.instance_template, 0)}"
+  }
+}
+
+data "google_compute_region_instance_group" "mig1" {
+  self_link  = "${module.mig1.region_instance_group}"
+  depends_on = ["null_resource.template"]
+}
+
+output "instance" {
+  value = "${lookup(data.google_compute_region_instance_group.mig1.instances[0], "instance")}"
+}

--- a/examples/regional/README.md
+++ b/examples/regional/README.md
@@ -1,0 +1,54 @@
+# Managed instance group regional example
+
+This example shows how to create a regional instance group and perform a rolling upgrade.
+
+## Setup Environment
+
+```
+gcloud auth application-default login
+export GOOGLE_PROJECT=$(gcloud config get-value project)
+```
+
+## Run Terraform
+
+```
+terraform init
+terraform plan
+terraform apply
+```
+
+The output variables display the 3 instances that were created and their current status.
+
+```
+terraform output
+```
+
+## Rolling upgrade
+
+Add a label to the instance template, this will trigger a rolling update.
+
+```
+cat > terraform.tfvars <<EOF
+labels {
+  created_by = "terraform"
+}
+EOF
+```
+
+```
+terraform apply
+```
+
+Verify the change has taken place on all new instances:
+
+```
+./test.sh label created_by terraform
+```
+
+## Clean up
+
+Remove all resources created by Terraform:
+
+```
+terraform destroy
+```

--- a/examples/regional/gceme.sh.tpl
+++ b/examples/regional/gceme.sh.tpl
@@ -1,0 +1,116 @@
+#!/bin/bash -xe
+
+apt-get update
+apt-get install -y apache2 php5
+
+# install lookbusy script to test autoscaling
+apt-get install -y build-essential git
+cd /tmp
+git clone https://github.com/beloglazov/cpu-load-generator.git
+./cpu-load-generator/install-lookbusy.sh
+cd -
+
+cat > /var/www/html/index.php <<'EOF'
+<?php
+function metadata_value($value) {
+    $opts = [
+        "http" => [
+            "method" => "GET",
+            "header" => "Metadata-Flavor: Google"
+        ]
+    ];
+    $context = stream_context_create($opts);
+    $content = file_get_contents("http://metadata/computeMetadata/v1/$value", false, $context);
+    return $content;
+}
+?>
+
+<!doctype html>
+<html>
+<head>
+<!-- Compiled and minified CSS -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.0/css/materialize.min.css">
+
+<!-- Compiled and minified JavaScript -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.0/js/materialize.min.js"></script>
+<title>Frontend Web Server</title>
+</head>
+<body>
+<div class="container">
+<div class="row">
+<div class="col s2">&nbsp;</div>
+<div class="col s8">
+
+
+<div class="card blue">
+<div class="card-content white-text">
+<div class="card-title">Backend that serviced this request</div>
+</div>
+<div class="card-content white">
+<table class="bordered">
+  <tbody>
+	<tr>
+	  <td>Name</td>
+	  <td><?php printf(metadata_value("instance/name")) ?></td>
+	</tr>
+	<tr>
+	  <td>ID</td>
+	  <td><?php printf(metadata_value("instance/id")) ?></td>
+	</tr>
+	<tr>
+	  <td>Hostname</td>
+	  <td><?php printf(metadata_value("instance/hostname")) ?></td>
+	</tr>
+	<tr>
+	  <td>Zone</td>
+	  <td><?php printf(metadata_value("instance/zone")) ?></td>
+	</tr>
+    <tr>
+	  <td>Machine Type</td>
+	  <td><?php printf(metadata_value("instance/machine-type")) ?></td>
+	</tr>
+	<tr>
+	  <td>Project</td>
+	  <td><?php printf(metadata_value("project/project-id")) ?></td>
+	</tr>
+	<tr>
+	  <td>Internal IP</td>
+	  <td><?php printf(metadata_value("instance/network-interfaces/0/ip")) ?></td>
+	</tr>
+	<tr>
+	  <td>External IP</td>
+	  <td><?php printf(metadata_value("instance/network-interfaces/0/access-configs/0/external-ip")) ?></td>
+	</tr>
+  </tbody>
+</table>
+</div>
+</div>
+
+<div class="card blue">
+<div class="card-content white-text">
+<div class="card-title">Proxy that handled this request</div>
+</div>
+<div class="card-content white">
+<table class="bordered">
+  <tbody>
+	<tr>
+	  <td>Address</td>
+	  <td><?php printf($_SERVER["HTTP_HOST"]); ?></td>
+	</tr>
+  </tbody>
+</table>
+</div>
+
+</div>
+</div>
+<div class="col s2">&nbsp;</div>
+</div>
+</div>
+</html>
+EOF
+sudo mv /var/www/html/index.html /var/www/html/index.html.old
+
+[[ -n "${PROXY_PATH}" ]] && mkdir -p /var/www/html/${PROXY_PATH} && cp /var/www/html/index.php /var/www/html/${PROXY_PATH}/index.php
+
+systemctl enable apache2
+systemctl restart apache2

--- a/examples/regional/main.tf
+++ b/examples/regional/main.tf
@@ -1,0 +1,103 @@
+variable "labels" {
+  type    = "map"
+  default = {}
+}
+
+variable "region" {
+  default = "us-central1"
+}
+
+provider "google" {
+  region = "${var.region}"
+}
+
+variable "network_name" {
+  default = "mig-regional-example"
+}
+
+resource "google_compute_network" "default" {
+  name                    = "${var.network_name}"
+  auto_create_subnetworks = "false"
+}
+
+resource "google_compute_subnetwork" "default" {
+  name                     = "${var.network_name}"
+  ip_cidr_range            = "10.127.0.0/20"
+  network                  = "${google_compute_network.default.self_link}"
+  region                   = "${var.region}"
+  private_ip_google_access = true
+}
+
+data "template_file" "startup-script" {
+  template = "${file("${format("%s/gceme.sh.tpl", path.module)}")}"
+
+  vars {
+    PROXY_PATH = ""
+  }
+}
+
+data "google_compute_zones" "available" {
+  region = "${var.region}"
+}
+
+module "mig1" {
+  source                    = "../../"
+  region                    = "${var.region}"
+  distribution_policy_zones = ["${data.google_compute_zones.available.names}"]
+  zonal                     = false
+  name                      = "${var.network_name}"
+  size                      = 3
+  target_tags               = ["${var.network_name}"]
+  service_port              = 80
+  service_port_name         = "http"
+  startup_script            = "${data.template_file.startup-script.rendered}"
+  wait_for_instances        = true
+  network                   = "${google_compute_subnetwork.default.name}"
+  subnetwork                = "${google_compute_subnetwork.default.name}"
+  instance_labels           = "${var.labels}"
+  update_strategy           = "ROLLING_UPDATE"
+
+  rolling_update_policy = [{
+    type                  = "PROACTIVE"
+    minimal_action        = "REPLACE"
+    max_surge_fixed       = 4
+    max_unavailable_fixed = 4
+    min_ready_sec         = 50
+  }]
+}
+
+// null resource used to create dependency with the instance group data source to trigger a refresh.
+resource "null_resource" "template" {
+  triggers {
+    instance_template = "${element(module.mig1.instance_template, 0)}"
+  }
+}
+
+data "google_compute_region_instance_group" "mig1" {
+  self_link  = "${module.mig1.region_instance_group}"
+  depends_on = ["null_resource.template"]
+}
+
+output "instance_self_link_1" {
+  value = "${lookup(data.google_compute_region_instance_group.mig1.instances[0], "instance")}"
+}
+
+output "instance_status_1" {
+  value = "${lookup(data.google_compute_region_instance_group.mig1.instances[0], "status")}"
+}
+
+output "instance_self_link_2" {
+  value = "${lookup(data.google_compute_region_instance_group.mig1.instances[1], "instance")}"
+}
+
+output "instance_status_2" {
+  value = "${lookup(data.google_compute_region_instance_group.mig1.instances[1], "status")}"
+}
+
+output "instance_self_link_3" {
+  value = "${lookup(data.google_compute_region_instance_group.mig1.instances[2], "instance")}"
+}
+
+output "instance_status_3" {
+  value = "${lookup(data.google_compute_region_instance_group.mig1.instances[2], "status")}"
+}

--- a/examples/regional/test.sh
+++ b/examples/regional/test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+
+function usage() {
+  echo "USAGE: $0 <label <name> <value>|no-label>"
+}
+
+MODE=$1
+
+[[ "${MODE}" != "label" && "${MODE}" != "no-label" ]] && usage && exit 1
+[[ "${MODE}" == "label" && -z "$2" ]] && echo "ERROR: Missing label name" && usage && exit 1
+[[ "${MODE}" == "label" && -z "$3" ]] && echo "ERROR: Missing label value" && usage && exit 1
+
+for i in `seq 1 3`; do
+  SELF_LINK=$(terraform output "instance_self_link_${i}")
+  STATUS=$(terraform output "instance_status_${i}")
+  if [[ "${SELF_LINK}" != "" && "${STATUS}" == "RUNNING" ]]; then
+    echo "INFO: Regional instance ${i} created and running."
+
+    if [[ "${MODE}" == "label" ]]; then
+      EXP_LABEL_NAME="${2}"
+      EXP_LABEL_VALUE="${3}"
+      ACT_LABEL_VALUE=$(gcloud compute instances describe "${SELF_LINK}" --format="value(labels.${EXP_LABEL_NAME})")
+      if [[ "${ACT_LABEL_VALUE}" == "${EXP_LABEL_VALUE}" ]]; then
+        echo "INFO: Found label ${EXP_LABEL_NAME}=${EXP_LABEL_VALUE} on ${SELF_LINK}"
+      else
+        echo "ERROR: Label ${EXP_LABEL_NAME}=${EXP_LABEL_VALUE} not found on ${SELF_LINK}"
+        exit 1
+      fi
+    else
+      # Verify no labels.
+      ACT_LABEL_VALUE=$(gcloud compute instances describe "${SELF_LINK}" --format="value(labels)")
+      if [[ "${ACT_LABEL_VALUE}" != "" ]]; then
+        echo "ERROR: Found labels on instance ${SELF_LINK}, epxected none."
+      fi
+    fi
+  else
+    echo "ERROR: Regional instance ${i} not found or is not running"
+    exit 1
+  fi
+done
+
+echo "INFO: PASS. All instances found and running."

--- a/examples/zonal/README.md
+++ b/examples/zonal/README.md
@@ -1,0 +1,54 @@
+# Managed instance group zonal example
+
+This example shows how to create a zonal instance group and perform a rolling upgrade.
+
+## Setup Environment
+
+```
+gcloud auth application-default login
+export GOOGLE_PROJECT=$(gcloud config get-value project)
+```
+
+## Run Terraform
+
+```
+terraform init
+terraform plan
+terraform apply
+```
+
+The output variables display the 3 instances that were created:
+
+```
+terraform output
+```
+
+## Rolling upgrade
+
+Add a label to the instance template, this will trigger a rolling update.
+
+```
+cat > terraform.tfvars <<EOF
+labels {
+  created_by = "terraform"
+}
+EOF
+```
+
+```
+terraform apply
+```
+
+Verify the change has taken place on all new instances:
+
+```
+./test.sh label created_by terraform
+```
+
+## Clean up
+
+Remove all resources created by Terraform:
+
+```
+terraform destroy
+```

--- a/examples/zonal/gceme.sh.tpl
+++ b/examples/zonal/gceme.sh.tpl
@@ -1,0 +1,116 @@
+#!/bin/bash -xe
+
+apt-get update
+apt-get install -y apache2 php5
+
+# install lookbusy script to test autoscaling
+apt-get install -y build-essential git
+cd /tmp
+git clone https://github.com/beloglazov/cpu-load-generator.git
+./cpu-load-generator/install-lookbusy.sh
+cd -
+
+cat > /var/www/html/index.php <<'EOF'
+<?php
+function metadata_value($value) {
+    $opts = [
+        "http" => [
+            "method" => "GET",
+            "header" => "Metadata-Flavor: Google"
+        ]
+    ];
+    $context = stream_context_create($opts);
+    $content = file_get_contents("http://metadata/computeMetadata/v1/$value", false, $context);
+    return $content;
+}
+?>
+
+<!doctype html>
+<html>
+<head>
+<!-- Compiled and minified CSS -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.0/css/materialize.min.css">
+
+<!-- Compiled and minified JavaScript -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.0/js/materialize.min.js"></script>
+<title>Frontend Web Server</title>
+</head>
+<body>
+<div class="container">
+<div class="row">
+<div class="col s2">&nbsp;</div>
+<div class="col s8">
+
+
+<div class="card blue">
+<div class="card-content white-text">
+<div class="card-title">Backend that serviced this request</div>
+</div>
+<div class="card-content white">
+<table class="bordered">
+  <tbody>
+	<tr>
+	  <td>Name</td>
+	  <td><?php printf(metadata_value("instance/name")) ?></td>
+	</tr>
+	<tr>
+	  <td>ID</td>
+	  <td><?php printf(metadata_value("instance/id")) ?></td>
+	</tr>
+	<tr>
+	  <td>Hostname</td>
+	  <td><?php printf(metadata_value("instance/hostname")) ?></td>
+	</tr>
+	<tr>
+	  <td>Zone</td>
+	  <td><?php printf(metadata_value("instance/zone")) ?></td>
+	</tr>
+    <tr>
+	  <td>Machine Type</td>
+	  <td><?php printf(metadata_value("instance/machine-type")) ?></td>
+	</tr>
+	<tr>
+	  <td>Project</td>
+	  <td><?php printf(metadata_value("project/project-id")) ?></td>
+	</tr>
+	<tr>
+	  <td>Internal IP</td>
+	  <td><?php printf(metadata_value("instance/network-interfaces/0/ip")) ?></td>
+	</tr>
+	<tr>
+	  <td>External IP</td>
+	  <td><?php printf(metadata_value("instance/network-interfaces/0/access-configs/0/external-ip")) ?></td>
+	</tr>
+  </tbody>
+</table>
+</div>
+</div>
+
+<div class="card blue">
+<div class="card-content white-text">
+<div class="card-title">Proxy that handled this request</div>
+</div>
+<div class="card-content white">
+<table class="bordered">
+  <tbody>
+	<tr>
+	  <td>Address</td>
+	  <td><?php printf($_SERVER["HTTP_HOST"]); ?></td>
+	</tr>
+  </tbody>
+</table>
+</div>
+
+</div>
+</div>
+<div class="col s2">&nbsp;</div>
+</div>
+</div>
+</html>
+EOF
+sudo mv /var/www/html/index.html /var/www/html/index.html.old
+
+[[ -n "${PROXY_PATH}" ]] && mkdir -p /var/www/html/${PROXY_PATH} && cp /var/www/html/index.php /var/www/html/${PROXY_PATH}/index.php
+
+systemctl enable apache2
+systemctl restart apache2

--- a/examples/zonal/main.tf
+++ b/examples/zonal/main.tf
@@ -1,0 +1,95 @@
+variable "labels" {
+  type    = "map"
+  default = {}
+}
+
+variable "region" {
+  default = "us-central1"
+}
+
+variable "zone" {
+  default = "us-central1-b"
+}
+
+provider "google" {
+  region = "${var.region}"
+}
+
+variable "network_name" {
+  default = "mig-zonal-example"
+}
+
+resource "google_compute_network" "default" {
+  name                    = "${var.network_name}"
+  auto_create_subnetworks = "false"
+}
+
+resource "google_compute_subnetwork" "default" {
+  name                     = "${var.network_name}"
+  ip_cidr_range            = "10.127.0.0/20"
+  network                  = "${google_compute_network.default.self_link}"
+  region                   = "${var.region}"
+  private_ip_google_access = true
+}
+
+data "template_file" "startup-script" {
+  template = "${file("${format("%s/gceme.sh.tpl", path.module)}")}"
+
+  vars {
+    PROXY_PATH = ""
+  }
+}
+
+data "google_compute_zones" "available" {
+  region = "${var.region}"
+}
+
+module "mig1" {
+  source             = "../../"
+  region             = "${var.region}"
+  zone               = "${var.zone}"
+  zonal              = true
+  name               = "${var.network_name}"
+  size               = 3
+  target_tags        = ["${var.network_name}"]
+  service_port       = 80
+  service_port_name  = "http"
+  startup_script     = "${data.template_file.startup-script.rendered}"
+  wait_for_instances = true
+  network            = "${google_compute_subnetwork.default.name}"
+  subnetwork         = "${google_compute_subnetwork.default.name}"
+  instance_labels    = "${var.labels}"
+  update_strategy    = "ROLLING_UPDATE"
+
+  rolling_update_policy = [{
+    type                  = "PROACTIVE"
+    minimal_action        = "REPLACE"
+    max_surge_fixed       = 4
+    max_unavailable_fixed = 4
+    min_ready_sec         = 50
+  }]
+}
+
+// null resource used to create dependency with the instance group data source to trigger a refresh.
+resource "null_resource" "template" {
+  triggers {
+    instance_template = "${element(module.mig1.instance_template, 0)}"
+  }
+}
+
+data "google_compute_instance_group" "mig1" {
+  self_link  = "${module.mig1.instance_group}"
+  depends_on = ["null_resource.template"]
+}
+
+output "instance_self_link_1" {
+  value = "${data.google_compute_instance_group.mig1.instances[0]}"
+}
+
+output "instance_self_link_2" {
+  value = "${data.google_compute_instance_group.mig1.instances[1]}"
+}
+
+output "instance_self_link_3" {
+  value = "${data.google_compute_instance_group.mig1.instances[2]}"
+}

--- a/examples/zonal/test.sh
+++ b/examples/zonal/test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+
+function usage() {
+  echo "USAGE: $0 <label <name> <value>|no-label>"
+}
+
+MODE=$1
+
+[[ "${MODE}" != "label" && "${MODE}" != "no-label" ]] && usage && exit 1
+[[ "${MODE}" == "label" && -z "$2" ]] && echo "ERROR: Missing label name" && usage && exit 1
+[[ "${MODE}" == "label" && -z "$3" ]] && echo "ERROR: Missing label value" && usage && exit 1
+
+for i in `seq 1 3`; do
+  SELF_LINK=$(terraform output "instance_self_link_${i}")
+  if [[ "${SELF_LINK}" != "" ]]; then
+    echo "INFO: Zonal instance ${i} created."
+
+    if [[ "${MODE}" == "label" ]]; then
+      EXP_LABEL_NAME="${2}"
+      EXP_LABEL_VALUE="${3}"
+      ACT_LABEL_VALUE=$(gcloud compute instances describe "${SELF_LINK}" --format="value(labels.${EXP_LABEL_NAME})")
+      if [[ "${ACT_LABEL_VALUE}" == "${EXP_LABEL_VALUE}" ]]; then
+        echo "INFO: Found label ${EXP_LABEL_NAME}=${EXP_LABEL_VALUE} on ${SELF_LINK}"
+      else
+        echo "ERROR: Label ${EXP_LABEL_NAME}=${EXP_LABEL_VALUE} not found on ${SELF_LINK}"
+        exit 1
+      fi
+    else
+      # Verify no labels.
+      ACT_LABEL_VALUE=$(gcloud compute instances describe "${SELF_LINK}" --format="value(labels)")
+      if [[ "${ACT_LABEL_VALUE}" != "" ]]; then
+        echo "ERROR: Found labels on instance ${SELF_LINK}, epxected none."
+      fi
+    fi
+  else
+    echo "ERROR: Zonal instance ${i} not found or is not running"
+    exit 1
+  fi
+done
+
+echo "INFO: PASS. All instances found and running."

--- a/main.tf
+++ b/main.tf
@@ -123,6 +123,17 @@ resource "google_compute_autoscaler" "default" {
   }
 }
 
+data "google_compute_zones" "available" {
+  region = "${var.region}"
+}
+
+locals {
+  distribution_zones = {
+    default = ["${data.google_compute_zones.available.names}"]
+    user    = ["${var.distribution_policy_zones}"]
+  }
+}
+
 resource "google_compute_region_instance_group_manager" "default" {
   count              = "${var.module_enabled && ! var.zonal ? 1 : 0}"
   project            = "${var.project}"
@@ -140,7 +151,7 @@ resource "google_compute_region_instance_group_manager" "default" {
 
   rolling_update_policy = ["${var.rolling_update_policy}"]
 
-  distribution_policy_zones = ["${var.distribution_policy_zones}"]
+  distribution_policy_zones = ["${local.distribution_zones["${length(var.distribution_policy_zones) == 0 ? "default" : "user"}"]}"]
 
   target_pools = ["${var.target_pools}"]
 

--- a/main.tf
+++ b/main.tf
@@ -76,8 +76,6 @@ resource "google_compute_instance_group_manager" "default" {
 
   update_strategy = "${var.update_strategy}"
 
-  rolling_update_policy = ["${var.rolling_update_policy}"]
-
   target_pools = ["${var.target_pools}"]
 
   // There is no way to unset target_size when autoscaling is true so for now, jsut use the min_replicas value.

--- a/main.tf
+++ b/main.tf
@@ -76,6 +76,8 @@ resource "google_compute_instance_group_manager" "default" {
 
   update_strategy = "${var.update_strategy}"
 
+  rolling_update_policy = ["${var.rolling_update_policy}"]
+
   target_pools = ["${var.target_pools}"]
 
   // There is no way to unset target_size when autoscaling is true so for now, jsut use the min_replicas value.

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,6 +19,11 @@ output name {
   value       = "${var.name}"
 }
 
+output instance_template {
+  description = "Link to the instance_template for the group"
+  value = "${google_compute_instance_template.default.*.self_link}"
+}
+
 output instance_group {
   description = "Link to the `instance_group` property of the instance group manager resource."
   value       = "${element(concat(google_compute_instance_group_manager.default.*.instance_group, list("")), 0)}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,7 +21,7 @@ output name {
 
 output instance_template {
   description = "Link to the instance_template for the group"
-  value = "${google_compute_instance_template.default.*.self_link}"
+  value       = "${google_compute_instance_template.default.*.self_link}"
 }
 
 output instance_group {

--- a/variables.tf
+++ b/variables.tf
@@ -102,7 +102,7 @@ variable wait_for_instances {
 
 variable update_strategy {
   description = "The strategy to apply when the instance template changes."
-  default     = "RESTART"
+  default     = "NONE"
 }
 
 variable rolling_update_policy {

--- a/variables.tf
+++ b/variables.tf
@@ -175,7 +175,7 @@ variable zonal {
 }
 
 variable distribution_policy_zones {
-  description = "The distribution policy for this managed instance group when zonal=false."
+  description = "The distribution policy for this managed instance group when zonal=false. Default is all zones in given region."
   type        = "list"
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -128,7 +128,7 @@ variable target_tags {
 variable instance_labels {
   description = "Labels added to instances."
   type        = "map"
-  default     = {}  
+  default     = {}
 }
 
 variable target_pools {


### PR DESCRIPTION
Module changes:
- default `update_strategy` to `NONE` to support both zonal and regional cases.
- output of instance_template self link to track changes.
- default `distribution_policy_zones` to all zones in region if none given.

New examples:
- zonal
- regional
- autoscaling