### PR TITLE
Update default image to debian-9

### DIFF
--- a/examples/autoscaling/gceme.sh.tpl
+++ b/examples/autoscaling/gceme.sh.tpl
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 
 apt-get update
-apt-get install -y apache2 php5
+apt-get install -y apache2 libapache2-mod-php
 
 # install lookbusy script to test autoscaling
 apt-get install -y build-essential git

--- a/examples/regional/gceme.sh.tpl
+++ b/examples/regional/gceme.sh.tpl
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 
 apt-get update
-apt-get install -y apache2 php5
+apt-get install -y apache2 libapache2-mod-php
 
 # install lookbusy script to test autoscaling
 apt-get install -y build-essential git

--- a/examples/zonal/gceme.sh.tpl
+++ b/examples/zonal/gceme.sh.tpl
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 
 apt-get update
-apt-get install -y apache2 php5
+apt-get install -y apache2 libapache2-mod-php
 
 # install lookbusy script to test autoscaling
 apt-get install -y build-essential git

--- a/main.tf
+++ b/main.tf
@@ -102,7 +102,6 @@ resource "google_compute_instance_group_manager" "default" {
   provisioner "local-exec" {
     when        = "create"
     command     = "${var.local_cmd_create}"
-    interpreter = ["sh", "-c"]
   }
 }
 
@@ -178,7 +177,11 @@ resource "google_compute_region_instance_group_manager" "default" {
   provisioner "local-exec" {
     when        = "create"
     command     = "${var.local_cmd_create}"
-    interpreter = ["sh", "-c"]
+  }
+
+  // Initial instance verification can take 10-15m when a health check is present.
+  timeouts = {
+    create = "${var.http_health_check ? "15m" : "5m"}"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -92,7 +92,7 @@ variable machine_type {
 
 variable compute_image {
   description = "Image used for compute VMs."
-  default     = "debian-cloud/debian-8"
+  default     = "debian-cloud/debian-9"
 }
 
 variable wait_for_instances {
@@ -248,7 +248,7 @@ variable http_health_check {
 
 variable hc_initial_delay {
   description = "Health check, intial delay in seconds."
-  default     = 300
+  default     = 30
 }
 
 variable hc_interval {


### PR DESCRIPTION
- update default image to debian-9
- reduce default health check delay to 30s
- increase timeout for regional creation with health checks
- removed default interpreter in local-exec hook

Fixes https://github.com/GoogleCloudPlatform/terraform-google-nat-gateway/issues/72
