### PR TITLE
Introduce disk mode

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,7 @@ resource "google_compute_instance_template" "default" {
     type         = "PERSISTENT"
     disk_type    = "${var.disk_type}"
     disk_size_gb = "${var.disk_size_gb}"
+    mode         = "${var.mode}"
   }
 
   service_account {

--- a/variables.tf
+++ b/variables.tf
@@ -66,7 +66,10 @@ variable startup_script {
 variable access_config {
   description = "The access config block for the instances. Set to [] to remove external IP."
   type        = "list"
-  default     = [{}]
+
+  default = [
+    {},
+  ]
 }
 
 variable metadata {
@@ -199,6 +202,11 @@ variable disk_type {
 variable disk_size_gb {
   description = "The size of the image in gigabytes. If not specified, it will inherit the size of its base image."
   default     = 0
+}
+
+variable mode {
+  description = "The mode in which to attach this disk, either READ_WRITE or READ_ONLY."
+  default     = "READ_WRITE"
 }
 
 variable "preemptible" {


### PR DESCRIPTION
Adding mode argument in disk block to allow READ_ONLY mode if necessary. 
By default, this argument uses the READ_WRITE mode.