### PR TITLE
Use the module_enabled flag for all resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -244,7 +244,7 @@ resource "google_compute_firewall" "default-ssh" {
 }
 
 resource "google_compute_health_check" "mig-health-check" {
-  count   = "${var.http_health_check ? 1 : 0}"
+  count   = "${var.module_enabled && var.http_health_check ? 1 : 0}"
   name    = "${var.name}"
   project = "${var.project}"
 
@@ -260,7 +260,7 @@ resource "google_compute_health_check" "mig-health-check" {
 }
 
 resource "google_compute_firewall" "mig-health-check" {
-  count   = "${var.http_health_check ? 1 : 0}"
+  count   = "${var.module_enabled && var.http_health_check ? 1 : 0}"
   project = "${var.subnetwork_project == "" ? var.project : var.subnetwork_project}"
   name    = "${var.name}-vm-hc"
   network = "${var.network}"


### PR DESCRIPTION
Currently, the module_enabled flag is ignored for the mig-health-check resources and only the http_health_check flag is used. This merge request will change that behaviour and make the module use both variables.