### PR TITLE
Feature/repair module and autoscaling example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 **/backend.tf
 **/terraform.tfvars
 **/values-*.yaml
+./examples/autoscaling/.terraform/
+./examples/autoscaling/terraform.tfstate
+./examples/autoscaling/terraform.tfstate.backup

--- a/README.md
+++ b/README.md
@@ -28,3 +28,78 @@ module "mig1" {
 - [`google_compute_instance_template.default`](https://www.terraform.io/docs/providers/google/r/compute_instance_template.html): The instance template assigned to the instance group.
 - [`google_compute_instance_group_manager.default`](https://www.terraform.io/docs/providers/google/r/compute_instance_group_manager.html): The instange group manager that uses the instance template and target pools. 
 - [`google_compute_firewall.default-ssh`](https://www.terraform.io/docs/providers/google/r/compute_firewall.html): Firewall rule to allow ssh access to the instances.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| access\_config | The access config block for the instances. Set to [] to remove external IP. | list | `<list>` | no |
+| automatic\_restart | Automatically restart the instance if terminated by GCP - Set to false if using preemptible instances | string | `"true"` | no |
+| autoscaling | Enable autoscaling. | string | `"false"` | no |
+| autoscaling\_cpu | Autoscaling, cpu utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#cpu_utilization | list | `<list>` | no |
+| autoscaling\_lb | Autoscaling, load balancing utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#load_balancing_utilization | list | `<list>` | no |
+| autoscaling\_metric | Autoscaling, metric policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#metric | list | `<list>` | no |
+| can\_ip\_forward | Allow ip forwarding. | string | `"false"` | no |
+| compute\_image | Image used for compute VMs. | string | `"projects/debian-cloud/global/images/family/debian-9"` | no |
+| cooldown\_period | Autoscaling, cooldown period in seconds. | string | `"60"` | no |
+| depends\_id | The ID of a resource that the instance group depends on. | string | `""` | no |
+| disk\_auto\_delete | Whether or not the disk should be auto-deleted. | string | `"true"` | no |
+| disk\_size\_gb | The size of the image in gigabytes. If not specified, it will inherit the size of its base image. | string | `"0"` | no |
+| disk\_type | The GCE disk type. Can be either pd-ssd, local-ssd, or pd-standard. | string | `"pd-ssd"` | no |
+| distribution\_policy\_zones | The distribution policy for this managed instance group when zonal=false. Default is all zones in given region. | list | `<list>` | no |
+| hc\_healthy\_threshold | Health check, healthy threshold. | string | `"1"` | no |
+| hc\_initial\_delay | Health check, intial delay in seconds. | string | `"30"` | no |
+| hc\_interval | Health check, check interval in seconds. | string | `"30"` | no |
+| hc\_path | Health check, the http path to check. | string | `"/"` | no |
+| hc\_port | Health check, health check port, if different from var.service_port, if not given, var.service_port is used. | string | `""` | no |
+| hc\_timeout | Health check, timeout in seconds. | string | `"10"` | no |
+| hc\_unhealthy\_threshold | Health check, unhealthy threshold. | string | `"10"` | no |
+| http\_health\_check | Enable or disable the http health check for auto healing. | string | `"true"` | no |
+| instance\_labels | Labels added to instances. | map | `<map>` | no |
+| local\_cmd\_create | Command to run on create as local-exec provisioner for the instance group manager. | string | `":"` | no |
+| local\_cmd\_destroy | Command to run on destroy as local-exec provisioner for the instance group manager. | string | `":"` | no |
+| machine\_type | Machine type for the VMs in the instance group. | string | `"f1-micro"` | no |
+| max\_replicas | Autoscaling, max replicas. | string | `"5"` | no |
+| metadata | Map of metadata values to pass to instances. | map | `<map>` | no |
+| min\_replicas | Autoscaling, min replics. | string | `"1"` | no |
+| mode | The mode in which to attach this disk, either READ_WRITE or READ_ONLY. | string | `"READ_WRITE"` | no |
+| module\_enabled |  | string | `"true"` | no |
+| name | Name of the managed instance group. | string | n/a | yes |
+| network | Name of the network to deploy instances to. | string | `"default"` | no |
+| network\_ip | Set the network IP of the instance in the template. Useful for instance groups of size 1. | string | `""` | no |
+| preemptible | Use preemptible instances - lower price but short-lived instances. See https://cloud.google.com/compute/docs/instances/preemptible for more details | string | `"false"` | no |
+| project | The project to deploy to, if not set the default provider project is used. | string | `""` | no |
+| region | Region for cloud resources. | string | `"us-central1"` | no |
+| service\_account\_email | The email of the service account for the instance template. | string | `"default"` | no |
+| service\_account\_scopes | List of scopes for the instance template service account | list | `<list>` | no |
+| service\_port | Port the service is listening on. | string | n/a | yes |
+| service\_port\_name | Name of the port the service is listening on. | string | n/a | yes |
+| size | Target size of the managed instance group. | string | `"1"` | no |
+| ssh\_fw\_rule | Whether or not the SSH Firewall Rule should be created | string | `"true"` | no |
+| ssh\_source\_ranges | Network ranges to allow SSH from | list | `<list>` | no |
+| startup\_script | Content of startup-script metadata passed to the instance template. | string | `""` | no |
+| subnetwork | The subnetwork to deploy to | string | `"default"` | no |
+| subnetwork\_project | The project the subnetwork belongs to. If not set, var.project is used instead. | string | `""` | no |
+| target\_pools | The target load balancing pools to assign this group to. | list | `<list>` | no |
+| target\_tags | Tag added to instances for firewall and networking. | list | `<list>` | no |
+| update\_policy | The upgrade policy to apply when the instance template changes. | list | `<list>` | no |
+| wait\_for\_instances | Wait for all instances to be created/updated before returning | string | `"false"` | no |
+| zonal | Create a single-zone managed instance group. If false, a regional managed instance group is created. | string | `"true"` | no |
+| zone | Zone for managed instance groups. | string | `"us-central1-f"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| depends\_id | Id of the dummy dependency created used for intra-module dependency creation with zonal groups. |
+| health\_check | The healthcheck for the managed instance group |
+| instance\_group | Link to the `instance_group` property of the instance group manager resource. |
+| instance\_template | Link to the instance_template for the group |
+| instances | List of instances in the instance group. Note that this can change dynamically depending on the current number of instances in the group and may be empty the first time read. |
+| name | Pass through of input `name`. |
+| network\_ip | Pass through of input `network_ip`. |
+| region\_depends\_id | Id of the dummy dependency created used for intra-module dependency creation with regional groups. |
+| region\_instance\_group | Link to the `instance_group` property of the region instance group manager resource. |
+| service\_port | Pass through of input `service_port`. |
+| service\_port\_name | Pass through of input `service_port_name`. |
+| target\_tags | Pass through of input `target_tags`. |

--- a/examples/autoscaling/README.md
+++ b/examples/autoscaling/README.md
@@ -8,8 +8,15 @@ Configure your environment to use your default Google Cloud credentials:
 
 ```bash
 gcloud auth application-default login
-export GOOGLE_PROJECT=$(gcloud config get-value project)
 ```
+Get your list of projects with e.g. 
+```bash
+gcloud projects list
+```
+and choose appropriate 'PROJECT_ID' then export with 
+```bash
+ export TF_VAR_project=(your_project_id)
+ ```
 
 ## Run Terraform
 
@@ -20,6 +27,8 @@ terraform init
 terraform plan
 terraform apply
 ```
+
+The public IP for the service is displayed as an output of the plan. In case it is not ready:
 
 Open URL of load balancer in browser after the load balancer is ready:
 
@@ -55,3 +64,18 @@ Remove all resources created by terraform:
 ```bash
 terraform destroy
 ```
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| network\_name |  | string | `"mig-autoscale-example"` | no |
+| project | The name for our project | string | n/a | yes |
+| region |  | string | `"us-central1"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| instance\_self\_link |  |
+| instance\_status |  |
+| service\_public\_ip | Public IP address to reach and test our deployment |

--- a/main.tf
+++ b/main.tf
@@ -153,7 +153,6 @@ resource "google_compute_region_instance_group_manager" "default" {
 
   base_instance_name = "${var.name}"
 
-  # instance_template = "${google_compute_instance_template.default.self_link}"
   version {
     name              = "${var.name}-default"
     instance_template = "${google_compute_instance_template.default.self_link}"

--- a/main.tf
+++ b/main.tf
@@ -15,10 +15,9 @@
  */
 
 resource "google_compute_instance_template" "default" {
-  count       = "${var.module_enabled ? 1 : 0}"
-  project     = "${var.project}"
-  name_prefix = "default-"
-
+  count        = "${var.module_enabled ? 1 : 0}"
+  project      = "${var.project}"
+  name_prefix  = "default-"
   machine_type = "${var.machine_type}"
 
   region = "${var.region}"
@@ -72,13 +71,11 @@ provider "google-beta" {
 }
 
 resource "google_compute_instance_group_manager" "default" {
-  provider           = "google-beta"
   count              = "${var.module_enabled && var.zonal ? 1 : 0}"
   project            = "${var.project}"
   name               = "${var.name}"
   description        = "compute VM Instance Group"
   wait_for_instances = "${var.wait_for_instances}"
-
   base_instance_name = "${var.name}"
 
   version {
@@ -86,8 +83,7 @@ resource "google_compute_instance_group_manager" "default" {
     instance_template = "${google_compute_instance_template.default.self_link}"
   }
 
-  zone = "${var.zone}"
-
+  zone          = "${var.zone}"
   update_policy = "${var.update_policy}"
 
   target_pools = ["${var.target_pools}"]
@@ -157,7 +153,11 @@ resource "google_compute_region_instance_group_manager" "default" {
 
   base_instance_name = "${var.name}"
 
-  instance_template = "${google_compute_instance_template.default.self_link}"
+  # instance_template = "${google_compute_instance_template.default.self_link}"
+  version {
+    name              = "${var.name}-default"
+    instance_template = "${google_compute_instance_template.default.self_link}"
+  }
 
   region = "${var.region}"
 

--- a/main.tf
+++ b/main.tf
@@ -66,10 +66,6 @@ resource "google_compute_instance_template" "default" {
   }
 }
 
-provider "google-beta" {
-  version = ">= 2.0.0"
-}
-
 resource "google_compute_instance_group_manager" "default" {
   count              = "${var.module_enabled && var.zonal ? 1 : 0}"
   project            = "${var.project}"

--- a/variables.tf
+++ b/variables.tf
@@ -103,13 +103,8 @@ variable wait_for_instances {
   default     = false
 }
 
-variable update_strategy {
-  description = "The strategy to apply when the instance template changes."
-  default     = "NONE"
-}
-
-variable rolling_update_policy {
-  description = "The rolling update policy when update_strategy is ROLLING_UPDATE"
+variable update_policy {
+  description = "The upgrade policy to apply when the instance template changes."
   type        = "list"
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,56 +14,56 @@
  * limitations under the License.
  */
 
-variable module_enabled {
+variable "module_enabled" {
   description = ""
   default     = true
 }
 
-variable project {
+variable "project" {
   description = "The project to deploy to, if not set the default provider project is used."
   default     = ""
 }
 
-variable region {
+variable "region" {
   description = "Region for cloud resources."
   default     = "us-central1"
 }
 
-variable zone {
+variable "zone" {
   description = "Zone for managed instance groups."
   default     = "us-central1-f"
 }
 
-variable network {
+variable "network" {
   description = "Name of the network to deploy instances to."
   default     = "default"
 }
 
-variable subnetwork {
+variable "subnetwork" {
   description = "The subnetwork to deploy to"
   default     = "default"
 }
 
-variable subnetwork_project {
+variable "subnetwork_project" {
   description = "The project the subnetwork belongs to. If not set, var.project is used instead."
   default     = ""
 }
 
-variable name {
+variable "name" {
   description = "Name of the managed instance group."
 }
 
-variable size {
+variable "size" {
   description = "Target size of the managed instance group."
   default     = 1
 }
 
-variable startup_script {
+variable "startup_script" {
   description = "Content of startup-script metadata passed to the instance template."
   default     = ""
 }
 
-variable access_config {
+variable "access_config" {
   description = "The access config block for the instances. Set to [] to remove external IP."
   type        = "list"
 
@@ -72,90 +72,90 @@ variable access_config {
   ]
 }
 
-variable metadata {
+variable "metadata" {
   description = "Map of metadata values to pass to instances."
   type        = "map"
   default     = {}
 }
 
-variable can_ip_forward {
+variable "can_ip_forward" {
   description = "Allow ip forwarding."
   default     = false
 }
 
-variable network_ip {
+variable "network_ip" {
   description = "Set the network IP of the instance in the template. Useful for instance groups of size 1."
   default     = ""
 }
 
-variable machine_type {
+variable "machine_type" {
   description = "Machine type for the VMs in the instance group."
   default     = "f1-micro"
 }
 
-variable compute_image {
+variable "compute_image" {
   description = "Image used for compute VMs."
   default     = "projects/debian-cloud/global/images/family/debian-9"
 }
 
-variable wait_for_instances {
+variable "wait_for_instances" {
   description = "Wait for all instances to be created/updated before returning"
   default     = false
 }
 
-variable update_policy {
+variable "update_policy" {
   description = "The upgrade policy to apply when the instance template changes."
   type        = "list"
   default     = []
 }
 
-variable service_port {
+variable "service_port" {
   description = "Port the service is listening on."
 }
 
-variable service_port_name {
+variable "service_port_name" {
   description = "Name of the port the service is listening on."
 }
 
-variable target_tags {
+variable "target_tags" {
   description = "Tag added to instances for firewall and networking."
   type        = "list"
   default     = ["allow-service"]
 }
 
-variable instance_labels {
+variable "instance_labels" {
   description = "Labels added to instances."
   type        = "map"
   default     = {}
 }
 
-variable target_pools {
+variable "target_pools" {
   description = "The target load balancing pools to assign this group to."
   type        = "list"
   default     = []
 }
 
-variable depends_id {
+variable "depends_id" {
   description = "The ID of a resource that the instance group depends on."
   default     = ""
 }
 
-variable local_cmd_create {
+variable "local_cmd_create" {
   description = "Command to run on create as local-exec provisioner for the instance group manager."
   default     = ":"
 }
 
-variable local_cmd_destroy {
+variable "local_cmd_destroy" {
   description = "Command to run on destroy as local-exec provisioner for the instance group manager."
   default     = ":"
 }
 
-variable service_account_email {
+variable "service_account_email" {
   description = "The email of the service account for the instance template."
   default     = "default"
 }
 
-variable service_account_scopes {
+variable "service_account_scopes" {
   description = "List of scopes for the instance template service account"
   type        = "list"
 
@@ -167,7 +167,7 @@ variable service_account_scopes {
   ]
 }
 
-variable zonal {
+variable "zonal" {
   description = "Create a single-zone managed instance group. If false, a regional managed instance group is created."
   default     = true
 }
@@ -178,28 +178,28 @@ variable distribution_policy_zones {
   default     = []
 }
 
-variable ssh_source_ranges {
+variable "ssh_source_ranges" {
   description = "Network ranges to allow SSH from"
   type        = "list"
   default     = ["0.0.0.0/0"]
 }
 
-variable disk_auto_delete {
+variable "disk_auto_delete" {
   description = "Whether or not the disk should be auto-deleted."
   default     = true
 }
 
-variable disk_type {
+variable "disk_type" {
   description = "The GCE disk type. Can be either pd-ssd, local-ssd, or pd-standard."
   default     = "pd-ssd"
 }
 
-variable disk_size_gb {
+variable "disk_size_gb" {
   description = "The size of the image in gigabytes. If not specified, it will inherit the size of its base image."
   default     = 0
 }
 
-variable mode {
+variable "mode" {
   description = "The mode in which to attach this disk, either READ_WRITE or READ_ONLY."
   default     = "READ_WRITE"
 }
@@ -215,86 +215,86 @@ variable "automatic_restart" {
 }
 
 /* Autoscaling */
-variable autoscaling {
+variable "autoscaling" {
   description = "Enable autoscaling."
   default     = false
 }
 
-variable max_replicas {
+variable "max_replicas" {
   description = "Autoscaling, max replicas."
   default     = 5
 }
 
-variable min_replicas {
+variable "min_replicas" {
   description = "Autoscaling, min replics."
   default     = 1
 }
 
-variable cooldown_period {
+variable "cooldown_period" {
   description = "Autoscaling, cooldown period in seconds."
   default     = 60
 }
 
-variable autoscaling_cpu {
+variable "autoscaling_cpu" {
   description = "Autoscaling, cpu utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#cpu_utilization"
   type        = "list"
   default     = []
 }
 
-variable autoscaling_metric {
+variable "autoscaling_metric" {
   description = "Autoscaling, metric policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#metric"
   type        = "list"
   default     = []
 }
 
-variable autoscaling_lb {
+variable "autoscaling_lb" {
   description = "Autoscaling, load balancing utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#load_balancing_utilization"
   type        = "list"
   default     = []
 }
 
 /* Health checks */
-variable http_health_check {
+variable "http_health_check" {
   description = "Enable or disable the http health check for auto healing."
   default     = true
 }
 
-variable hc_initial_delay {
+variable "hc_initial_delay" {
   description = "Health check, intial delay in seconds."
   default     = 30
 }
 
-variable hc_interval {
+variable "hc_interval" {
   description = "Health check, check interval in seconds."
   default     = 30
 }
 
-variable hc_timeout {
+variable "hc_timeout" {
   description = "Health check, timeout in seconds."
   default     = 10
 }
 
-variable hc_healthy_threshold {
+variable "hc_healthy_threshold" {
   description = "Health check, healthy threshold."
   default     = 1
 }
 
-variable hc_unhealthy_threshold {
+variable "hc_unhealthy_threshold" {
   description = "Health check, unhealthy threshold."
   default     = 10
 }
 
-variable hc_port {
+variable "hc_port" {
   description = "Health check, health check port, if different from var.service_port, if not given, var.service_port is used."
   default     = ""
 }
 
-variable hc_path {
+variable "hc_path" {
   description = "Health check, the http path to check."
   default     = "/"
 }
 
-variable ssh_fw_rule {
+variable "ssh_fw_rule" {
   description = "Whether or not the SSH Firewall Rule should be created"
   default     = true
 }


### PR DESCRIPTION
I have built on @dcaba fork to make this module and the 'autoscaling' example work with current provider versions

In 'autoscaling' example:

* Fixes for current version providers
* Add service public IP ouput
* Improve runbook 
* Add Terraform inputs and outputs to README

In Module:

* Fix provider for google_beta provider
* Fix google_compute_region_instance_group_manager.default config
* Add Terraform inputs and outputs to README
* Add quotes variable names - advised best practice and much easier in IDE
